### PR TITLE
netsnmp/_api.h: libsnmp40 compatiblity, closes #18

### DIFF
--- a/netsnmp/_api.h
+++ b/netsnmp/_api.h
@@ -10,10 +10,10 @@
 #define Py_String PyString_AsString
 #endif
 
-int _debug_level;
+static int _debug_level;
 
 /* Exceptions */
-PyObject *SNMPError;
+static PyObject *SNMPError;
 
 /* Functions */
 long long __py_attr_long (PyObject *obj, char *attr_name);


### PR DESCRIPTION
fix the following errors by setting the variables static:
```
3.10 -c netsnmp/session.c -o build/temp.linux-x86_64-cpython-310/netsnmp/session.o
      x86_64-linux-gnu-gcc -shared -Wl,-O1 -Wl,-Bsymbolic-functions -Wl,-Bsymbolic-functions -g -fwrapv -O2 build/temp.linux-x86_64-cpython-310/netsnmp/_api.o build/temp.linux-x86_64-cpython-310/netsnmp/get.o build/temp.linux-x86_64-cpython-310/netsnmp/get_async.o build/temp.linux-x86_64-cpython-310/netsnmp/interface.o build/temp.linux-x86_64-cpython-310/netsnmp/session.o -L/usr/lib/x86_64-linux-gnu -L/usr/lib/x86_64-linux-gnu -lnetsnmp -lm -lssl -lssl -lcrypto -lzmq -lczmq -o build/lib.linux-x86_64-cpython-310/netsnmp/_api.cpython-310-x86_64-linux-gnu.so
      /usr/bin/ld: build/temp.linux-x86_64-cpython-310/netsnmp/get.o:/tmp/pip-req-build-jscb7e3o/./netsnmp/_api.h:16: multiple definition of `SNMPError'; build/temp.linux-x86_64-cpython-310/netsnmp/_api.o:/tmp/pip-req-build-jscb7e3o/./netsnmp/_api.h:16: first defined here
      /usr/bin/ld: build/temp.linux-x86_64-cpython-310/netsnmp/get.o:/tmp/pip-req-build-jscb7e3o/./netsnmp/_api.h:13: multiple definition of `_debug_level'; build/temp.linux-x86_64-cpython-310/netsnmp/_api.o:/tmp/pip-req-build-jscb7e3o/./netsnmp/_api.h:13: first defined here
      /usr/bin/ld: build/temp.linux-x86_64-cpython-310/netsnmp/get_async.o:/tmp/pip-req-build-jscb7e3o/./netsnmp/_api.h:13: multiple definition of `_debug_level'; build/temp.linux-x86_64-cpython-310/netsnmp/_api.o:/tmp/pip-req-build-jscb7e3o/./netsnmp/_api.h:13: first defined here
      /usr/bin/ld: build/temp.linux-x86_64-cpython-310/netsnmp/get_async.o:/tmp/pip-req-build-jscb7e3o/./netsnmp/_api.h:16: multiple definition of `SNMPError'; build/temp.linux-x86_64-cpython-310/netsnmp/_api.o:/tmp/pip-req-build-jscb7e3o/./netsnmp/_api.h:16: first defined here
      /usr/bin/ld: build/temp.linux-x86_64-cpython-310/netsnmp/interface.o:/tmp/pip-req-build-jscb7e3o/./netsnmp/_api.h:16: multiple definition of `SNMPError'; build/temp.linux-x86_64-cpython-310/netsnmp/_api.o:/tmp/pip-req-build-jscb7e3o/./netsnmp/_api.h:16: first defined here
      /usr/bin/ld: build/temp.linux-x86_64-cpython-310/netsnmp/interface.o:/tmp/pip-req-build-jscb7e3o/./netsnmp/_api.h:13: multiple definition of `_debug_level'; build/temp.linux-x86_64-cpython-310/netsnmp/_api.o:/tmp/pip-req-build-jscb7e3o/./netsnmp/_api.h:13: first defined here
      /usr/bin/ld: build/temp.linux-x86_64-cpython-310/netsnmp/session.o:/tmp/pip-req-build-jscb7e3o/./netsnmp/_api.h:13: multiple definition of `_debug_level'; build/temp.linux-x86_64-cpython-310/netsnmp/_api.o:/tmp/pip-req-build-jscb7e3o/./netsnmp/_api.h:13: first defined here
      /usr/bin/ld: build/temp.linux-x86_64-cpython-310/netsnmp/session.o:/tmp/pip-req-build-jscb7e3o/./netsnmp/_api.h:16: multiple definition of `SNMPError'; build/temp.linux-x86_64-cpython-310/netsnmp/_api.o:/tmp/pip-req-build-jscb7e3o/./netsnmp/_api.h:16: first defined here
```

I used this with 
```
# apt-get install libsnmp40 libsnmp-dev libczmq4 libczmq-dev
# pip3 install pyzmq
# pip3 install netsnmp-py
```
on a Ubuntu 22.04 jammy, but it still works with
```
# apt-get install libsnmp30 libsnmp30-dev libczmq3 libczmq-dev
# pip3 install pyzmq
# pip3 install netsnmp-py
```
on a Ubuntu 18.04 bionic. So it looks to me like my changes aren't breaking compatibility to `libsnmp30`. 

Since you are referencing a Debian version with `libsnmp30 libsnmp30-dev libczmq3` and `python3` as testing/unstable in the Readme.md file, I haven't changed this, yet. But I'm pretty sure you won't find them in Debian bookworm anymore as well. 

This looks to me, like this unstable/testing was buster once. Since bullseye already has libsnmp40. ;-)